### PR TITLE
 npm install --global cross-env

### DIFF
--- a/README_OLD.md
+++ b/README_OLD.md
@@ -936,6 +936,9 @@ En ocasiones puede haber problemas si la máquina virtual se ejecuta en un host 
 ```bash
 npm install --no-bin-links
 ```
+```bash
+npm install --global cross-env
+```
 #### 4. Compilar el código JS y CSS mediante Webpack:
 ```bash
 npm run dev


### PR DESCRIPTION
Muchas personas nos hemos encontrado con un error al realizar la instalación de npm en homestead dentro de un host windows. Salta el siguiente error al realizar la compilación con npm run dev:  "sh: 1: cross-env: not found npm ERR! code ELIFECYCLE". Para solucionarlo es necesario ejecutar el comando  npm install --global cross-env previamente para que la dependencia cross-env funcione globalmente en lugar de a nivel de proyecto. Más información en éste link https://stackoverflow.com/questions/43685777/laravel-mix-sh-1-cross-env-not-found-error